### PR TITLE
Deref JSON refs in swagger files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ docutils==0.12
 futures==3.0.5
 Jinja2==2.8
 jmespath==0.9.0
+jsonref==0.1
 lambda-uploader==1.0.0
 MarkupSafe==0.23
 python-dateutil==2.5.3

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'futures==3.0.5',
         'Jinja2==2.8',
         'jmespath==0.9.0',
+        'jsonref==0.1',
         'lambda-uploader==1.0.0',
         'MarkupSafe==0.23',
         'python-dateutil==2.5.3',


### PR DESCRIPTION
The AWS API operations for importing swagger files is still a bit wonky and fails if your swagger file contains JSON schema refs in certain places. This derefs swagger files before upload in order to prevent issues.