### PR TITLE
Fix error in argument help

### DIFF
--- a/yoke/shell.py
+++ b/yoke/shell.py
@@ -54,9 +54,10 @@ def main(arv=None):
     deploy_parser.add_argument('--stage', dest='stage', help='Stage to deploy',
                                default=os.getenv('YOKE_STAGE'))
     deploy_parser.add_argument('--environment', '-e', dest='environment',
-                               help=('Extra config values for lambda'
-                                     'environment. Format: KEYNAME=VALUE',),
-                               default=[], action='append')
+                               help=('Extra config values for lambda '
+                                     'config - can be used multiple times'),
+                               default=[], action='append',
+                               metavar='KEYNAME=VALUE')
     deploy_parser.add_argument('project_dir', default=os.getcwd(), nargs='?',
                                help='Project directory containing yoke.yml')
     deploy_parser.set_defaults(func=deploy_app)
@@ -66,9 +67,10 @@ def main(arv=None):
     deploy_parser.add_argument('--stage', dest='stage', help='Stage to build',
                                default=os.getenv('YOKE_STAGE'))
     deploy_parser.add_argument('--environment', '-e', dest='environment',
-                               help=('Extra config values for lambda'
-                                     'environment. Format: KEYNAME=VALUE',),
-                               default=[], action='append')
+                               help=('Extra config values for lambda '
+                                     'config - can be used multiple times'),
+                               default=[], action='append',
+                               metavar='KEYNAME=VALUE')
     deploy_parser.add_argument('project_dir', default=os.getcwd(), nargs='?',
                                help='Project directory containing yoke.yml')
     deploy_parser.set_defaults(func=build)


### PR DESCRIPTION
There was a trailing comma in the `help=` string that was leading to `argparse` treating it as a tuple. Also, added a `metavar` value to make the help string look right:

```
# yoke build -h
usage: yoke build [-h] [--stage STAGE] [--environment KEYNAME=VALUE]
                  [project_dir]

positional arguments:
  project_dir           Project directory containing yoke.yml

optional arguments:
  -h, --help            show this help message and exit
  --stage STAGE         Stage to build
  --environment KEYNAME=VALUE, -e KEYNAME=VALUE
                        Extra config values for lambda config - can be used
                        multiple times
```