### PR TITLE
Fix regex matching issue with response templates

### DIFF
--- a/yoke/templates.py
+++ b/yoke/templates.py
@@ -38,7 +38,7 @@ RESPONSE_CODES = [
     505,
 ]
 DEFAULT_RESPONSES = {
-    '^{rc}'.format(rc=resp_code): {
+    '^{rc}:.*'.format(rc=resp_code): {
         'responseTemplates': {
             'application/json': (
                 APPLICATION_JSON_RESPONSE_FMT % dict(rc=resp_code)


### PR DESCRIPTION
The response code templates were updated with a regex issue that caused the final version to be:
```
^{status_code}
```
instead of
```
^{status_code}:.*
```

This caused API Gateway integration responses to not find matching response templates and instead return the default response code (`200`) with passthrough.