### PR TITLE
Explicitly use overwrite mode for updating REST APIs

### DIFF
--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -174,6 +174,7 @@ class Deployment(object):
         if api:
             LOG.warning("API %s already exists - updating ...", api['name'])
             api = client.put_rest_api(restApiId=api['id'],
+                                      mode='overwrite',
                                       body=json.dumps(upload_body),
                                       parameters=parameters)
         else:


### PR DESCRIPTION
Weird things happen if we don't explicitly tell API Gateway to overwrite the existing API G model with the imported one from Swagger.