### PR TITLE
Update secretConfig output to include config-friendly fields

### DIFF
--- a/yoke/utils.py
+++ b/yoke/utils.py
@@ -36,7 +36,7 @@ def encrypt(config, output=False):
     resp = kms.encrypt(KeyId=key_name,
                        Plaintext=bytes(json.dumps(secret_config)))
     if output:
-        print('Encrypted config for stage {}:\n\n{}'.format(
+        print('Encrypted config for stage {}:\nsecretConfig: "{}"\n'.format(
             config['stage'],
             base64.b64encode(resp['CiphertextBlob'])))
 


### PR DESCRIPTION
Before:

```
$ yoke encrypt --stage dev
Getting config from /Users/bob/myproject ...
Loading stage dev ...
Getting AWS Account Credentials ...
Encrypted config for stage dev:

<long_encrypted_hash>
```

After:

```
$ yoke encrypt --stage dev
Getting config from /Users/bob/myproject ...
Loading stage dev ...
Getting AWS Account Credentials ...
Encrypted config for stage dev:
secretConfig: "<quoted_long_encrypted_hash>"
```
