### PR TITLE
Don't install deps - just build pkg

### DIFF
--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -47,8 +47,13 @@ class Deployment(object):
 
     def build_lambda_package(self):
         LOG.warning("Building Lambda package ...")
-        pkg = package.build_package(self.lambda_path, None,
-                                    extra_files=self.extra_files)
+        pkg = package.Package(self.lambda_path)
+        pkg._requirements_file = None
+        if self.extra_files:
+            for _file in self.extra_files:
+                pkg.extra_file(_file)
+        pkg._prepare_workspace()
+        pkg.package()
         pkg.clean_workspace()
         return pkg
 


### PR DESCRIPTION
When using `build_package` from Lambda Uploader it is now trying to install requirements despite us passing `None` for `requires`. This patch sacrifices some best practices (using private functions of the package.Package class) for working code. Considering the nature of Lambda Uploader, it may be worthwhile to stop using it in favor of just zipping and uploading ourselves in the future.