### PR TITLE
Workaround for Lambda API bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-boto3==1.4.0
-botocore==1.4.24
+boto3==1.4.2
+botocore==1.4.85
 Jinja2==2.8
 jsonref==0.1
-lambda-uploader==1.0.3
+lambda-uploader==1.1.0
 retrying==1.3.3
 ruamel.yaml==0.11.11

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'botocore>=1.4.85',
         'Jinja2==2.8',
         'jsonref==0.1',
-        'lambda-uploader==1.0.3',
+        'lambda-uploader==1.1.0',
         'retrying==1.3.3',
         'ruamel.yaml==0.11.11',
     ],

--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -262,4 +262,7 @@ class Deployment(object):
     def _format_vpc_config(self):
 
         # todo(ryandub): Add VPC support
-        return {}
+        return {
+            'SecurityGroupIds': [],
+            'SubnetIds': [],
+        }


### PR DESCRIPTION
If `VpcConfig` is empty, Lambda API will (intermittently?) return an error:
```
ClientError: An error occurred (InvalidParameterValueException) when calling the UpdateFunctionConfiguration operation: SubnetIds and SecurityIds must coexist or be both empty list.
```
The workaround from AWS as indicated [here](https://forums.aws.amazon.com/thread.jspa?messageID=760901&threadID=246719&tstart=0) is to pass the `SecurityGroupIds` and `SubnetIds` keys as empty arrays.