### PR TITLE
add missing runtime to lambda uploader configuration

### DIFF
--- a/examples/just_lambda/yoke.yml
+++ b/examples/just_lambda/yoke.yml
@@ -5,6 +5,7 @@ Lambda:
     handler: "handler.lambda_handler"
     timeout: 300
     memory: 256
+    runtime: "python2.7"
     ignore: ["/*.pyc"]
     role: "lambda_basic_execution"
   path: './src'

--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -65,6 +65,8 @@ class Deployment(object):
         Lambda['config']['alias'] = self.stage
         Lambda['config']['alias_description'] = Lambda['config']['description']
         Lambda['config']['region'] = self.region
+        Lambda['config']['runtime'] = Lambda['config'].get('runtime',
+                                                           'python2.7')
         Lambda['config']['variables'] = {}
         ordered = OrderedDict(sorted(Lambda['config'].items(),
                                      key=lambda x: x[1]))


### PR DESCRIPTION
Lambda uploader requires the `runtime` to be set in the configuration. It appears this is only for brand new lambdas, which we probably don't do very often.