### PR TITLE
Support Python 3.6 (for yoke itself)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The heart of Yoke is the `yoke.yml` file. This file tells Yoke all the necessary
     * `ignore`: A list of regex patterns of files to exclude when building and uploading the function.
     * `role`: The IAM role to assume when this function is run.
     * `runtime`: Lambda Runtime (default: `python2.7`).
+    * `vpc`: Optional VPC configuration, when specified, both keys below are required (also make sure that [permissions are set up accordingly](http://docs.aws.amazon.com/lambda/latest/dg/vpc-ec-create-iam-role.html)):
+      * `subnets`: List of subnets the Lambda function should run inside
+      * `security_groups`: List of security groups the Lambda function should assume
   * `path`: The path to the root of your Lambda module.
   * `extraFiles`: A list of additional files or directories to include in the Lambda package when uploading. This is useful for including requirements using `pip install -t <requirements_directory> <somepackage>`.
   * `dependencies`: Optional information about dependencies of the function:

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     install_requires=INSTALL_REQUIRES,
     classifiers=[
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
     ],
     license=license,
     author="Rackers",

--- a/yoke/__init__.py
+++ b/yoke/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 __title__ = 'yoke'
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2017'
 __url__ = 'https://github.com/rackerlabs/yoke'

--- a/yoke/build_deps.py
+++ b/yoke/build_deps.py
@@ -116,7 +116,7 @@ class PythonDependencyBuilder(object):
 
         requirements_file = os.path.join(self.lambda_path, 'requirements.txt')
         with open(requirements_file, 'r') as fp:
-            calculated_sha1sum = sha1(fp.read()).hexdigest()
+            calculated_sha1sum = sha1(fp.read().encode('utf-8')).hexdigest()
 
         if sha1sum != calculated_sha1sum:
             LOG.warning("SHA1 mismatch, rebuilding dependencies.")
@@ -200,7 +200,7 @@ class PythonDependencyBuilder(object):
         with open(filename, 'w') as fp:
             fp.write(contents)
 
-        os.chmod(filename, 0755)
+        os.chmod(filename, 0o755)
         return filename
 
     def generate_build_script(self):

--- a/yoke/build_deps.py
+++ b/yoke/build_deps.py
@@ -40,8 +40,16 @@ def wait_for_container_to_finish(container):
             basepath,
             'container_{}.log'.format(container.short_id),
         )
+        log_contents = container.logs(stdout=True, stderr=True)
         with open(log_filename, 'w') as fp:
-            fp.write(container.logs(stdout=True, stderr=True))
+            try:
+                fp.write(log_contents)
+            except TypeError:
+                # On Python 3, `fp.write()` expects a string instead of bytes
+                # (which is coming out of the `logs()` call), but Python 2
+                # can't handle writing unicode to a file, so we can't do this
+                # in both cases.
+                fp.write(log_contents.decode('utf-8'))
 
         raise Exception(
             "Container exited with non-zero code. Logs saved to {}".format(

--- a/yoke/config.py
+++ b/yoke/config.py
@@ -6,7 +6,7 @@ import os
 import re
 import ruamel.yaml as yaml
 
-import utils
+from . import utils
 
 LOG = logging.getLogger(__name__)
 LAMBDA_ROLE_ARN_TEMPLATE = "arn:aws:iam::{account_id}:role/{role}"
@@ -43,7 +43,7 @@ class YokeConfig(object):
         if 'config' not in config['stages'][self.stage]:
             config['stages'][self.stage]['config'] = {}
 
-        if self._args.func.func_name not in ['encrypt', 'decrypt']:
+        if self._args.func.__name__ not in ['encrypt', 'decrypt']:
             if (config['stages'][self.stage].get('secret_config') or
                     config['stages'][self.stage].get('secretConfig')):
                 dec_config = utils.decrypt(config)

--- a/yoke/config.py
+++ b/yoke/config.py
@@ -82,8 +82,8 @@ class YokeConfig(object):
         except ClientError as exc:
             LOG.debug("Failed to get account via get_user()...\n %s",
                       str(exc))
-            aws_account_id = boto3.client('iam').list_users(MaxItems=1)[
-                'Users'][0]['Arn'].split(':')[4]
+            aws_account_id = boto3.client('sts').get_caller_identity()[
+                'Account']
 
         return str(aws_account_id)
 

--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -267,8 +267,8 @@ class Deployment(object):
             aws_account_id = boto3.client('iam').get_user()[
                 'User']['Arn'].split(':')[4]
         except ClientError:
-            aws_account_id = boto3.client('iam').list_users(MaxItems=1)[
-                'Users'][0]['Arn'].split(':')[4]
+            aws_account_id = boto3.client('sts').get_caller_identity()[
+                'Account']
         try:
             assert aws_account_id == self.account_id
         except Exception:

--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -122,6 +122,7 @@ class Deployment(object):
         Lambda['config']['runtime'] = Lambda['config'].get('runtime',
                                                            'python2.7')
         Lambda['config']['variables'] = {}
+        Lambda['config']['raw'] = {'vpc': Lambda['config'].get('vpc')}
         ordered = OrderedDict(sorted(Lambda['config'].items(),
                                      key=lambda x: str(x[1])))
         upldr_config = namedtuple('config', ordered.keys())(**ordered)
@@ -254,7 +255,6 @@ class Deployment(object):
         LOG.warning("Uploading Lambda %s to AWS Account %s "
                     "for region %s ...",
                     upldr_config.name, self.account_id, upldr_config.region)
-        uploader.PackageUploader._format_vpc_config = self._format_vpc_config
         upldr = uploader.PackageUploader(upldr_config, None)
         upldr.upload(pkg)
         upldr.alias()
@@ -317,11 +317,3 @@ class Deployment(object):
         self.write_template(deref, filename='swagger.json')
 
         return deref
-
-    def _format_vpc_config(self):
-
-        # todo(ryandub): Add VPC support
-        return {
-            'SecurityGroupIds': [],
-            'SubnetIds': [],
-        }

--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -13,9 +13,9 @@ from lambda_uploader import package, uploader
 from retrying import retry
 import ruamel.yaml as yaml
 
-from build_deps import PythonDependencyBuilder
-import templates
-import utils
+from .build_deps import PythonDependencyBuilder
+from . import templates
+from . import utils
 
 LOG = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class Deployment(object):
                                                            'python2.7')
         Lambda['config']['variables'] = {}
         ordered = OrderedDict(sorted(Lambda['config'].items(),
-                                     key=lambda x: x[1]))
+                                     key=lambda x: str(x[1])))
         upldr_config = namedtuple('config', ordered.keys())(**ordered)
         return upldr_config
 

--- a/yoke/shell.py
+++ b/yoke/shell.py
@@ -3,10 +3,9 @@ import logging
 import os
 import sys
 
-from . import __version__
-import config
-import deploy
-import utils
+from . import config
+from . import deploy
+from . import utils
 
 LOG = logging.getLogger(__name__)
 
@@ -45,7 +44,6 @@ def encrypt(args):
 
 def main(arv=None):
     parser = argparse.ArgumentParser(
-        version='version {}'.format(__version__),
         description='AWS Lambda + API Gateway Deployment Tool'
     )
 


### PR DESCRIPTION
Did a quick smoke test on Python 2.7, and things still seem to work. Had to remove `version` from the `ArgumentParser`, it's not even documented on 2.7, but 3.6 just raises an exception.