### PR TITLE
Add default for missing tracing config

### DIFF
--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -123,6 +123,8 @@ class Deployment(object):
                                                            'python2.7')
         Lambda['config']['variables'] = {}
         Lambda['config']['raw'] = {'vpc': Lambda['config'].get('vpc')}
+        if not Lambda['config'].get('tracing'):
+            Lambda['config']['tracing'] = {}
         ordered = OrderedDict(sorted(Lambda['config'].items(),
                                      key=lambda x: str(x[1])))
         upldr_config = namedtuple('config', ordered.keys())(**ordered)


### PR DESCRIPTION
The latest version of `lambda-uploader` supports tracing in the Lambda config, but the way we generate the config for `lambda-uploader` causes an issue if the value isn't present. This adds an empty default if the key is not found.