### PR TITLE
Make `build` and `deploy` easier to call from code

### DIFF
--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -22,6 +22,30 @@ LOG = logging.getLogger(__name__)
 API_GATEWAY_URL_TEMPLATE = "https://{}.execute-api.{}.amazonaws.com/{}"
 
 
+def build(config):
+    LOG.warning('Building deployment only ...')
+    deployment = Deployment(config)
+    deployment.write_lambda_json()
+    deployment.write_lambda_config()
+    if config.get('apiGateway'):
+        template = deployment.render_swagger()
+        swagger_file = deployment.write_template(template)
+        # Also write the deref'd JSON version
+        deployment.deref(template)
+        LOG.warning('API Gateway Swagger file written to {}'.format(
+                    swagger_file))
+
+    deployment.build_lambda_package()
+
+
+def deploy_app(config):
+    deployment = Deployment(config)
+    deployment.deploy_lambda()
+    if config.get('apiGateway'):
+        deployment.deploy_api()
+    LOG.warning('Deployment complete!')
+
+
 class Deployment(object):
 
     def __init__(self, config):

--- a/yoke/shell.py
+++ b/yoke/shell.py
@@ -11,19 +11,7 @@ LOG = logging.getLogger(__name__)
 
 
 def build(args):
-    LOG.warning('Building deployment only ...')
-    deployment = deploy.Deployment(args.config)
-    deployment.write_lambda_json()
-    deployment.write_lambda_config()
-    if args.config.get('apiGateway'):
-        template = deployment.render_swagger()
-        swagger_file = deployment.write_template(template)
-        # Also write the deref'd JSON version
-        deployment.deref(template)
-        LOG.warning('API Gateway Swagger file written to {}'.format(
-                    swagger_file))
-
-    deployment.build_lambda_package()
+    deploy.build(args.config)
 
 
 def decrypt(args):
@@ -31,11 +19,7 @@ def decrypt(args):
 
 
 def deploy_app(args):
-    deployment = deploy.Deployment(args.config)
-    deployment.deploy_lambda()
-    if args.config.get('apiGateway'):
-        deployment.deploy_api()
-    LOG.warning('Deployment complete!')
+    deploy.deploy_app(args.config)
 
 
 def encrypt(args):


### PR DESCRIPTION
Decouple the CLI and yoke's API in so that yoke's API can be called
directly from another body of code. This is just a minor refactoring and
doesn't change any behavior.