### PR TITLE
Build C libraries from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# Visual Studio Code files
+.vscode/

--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ The heart of Yoke is the `yoke.yml` file. This file tells Yoke all the necessary
   * `dependencies`: Optional information about dependencies of the function:
     * `build`: If set to `true`, the Python dependencies listed in the Lambda function's `requirements.txt` file will be built and packaged with the function (default: `false`).
     * `wheelhouse`: The path to the directory where the dependency packages will be stored (in wheel format, default: `../../wheelhouse`).
-    * `install_dir`: The path to the directory where the dependencies will be installed (should be added to `extraFiles` above as well, otherwise they won't be included in the Lambda package, default: `./lib`).
-    * `packages`: List of CentOS package names that should be installed before the dependencies are built. The following packages are installed regardless of what is provided here: `libffi-devel` and `openssl-devel`. Default: no additional packages.
+    * `install_dir`: The path to the directory where the dependencies will be installed (should be added to `extraFiles` above as well, otherwise they won't be included in the Lambda package, default: `./lib`). Be careful, because this directory, and all its contents are removed before every build.
+    * `packages`: List of CentOS package names that should be installed before the dependencies are built. Default: no additional packages.
+    * `openssl`: Enable building a newer version of OpenSSL (the build image has 0.9.8, which isn't supported anymore), currently `1.0.2l`. Default: `false`.
+    * `libffi`: Enable building a newer version of [libffi](https://sourceware.org/libffi/), currently `3.2.1`. Default: `false`.
+    * `libxml`: Enable building a newer version of libxml2 and libxlst, currently `2.9.2` and `1.1.29`. Default: `false`.
 * `apiGateway`: Optional - information about API Gateway configuration.
   * `name`: The name of the API Gateway.
   * `swaggerTemplate`: Path to the Swagger template file.

--- a/yoke/build_deps.py
+++ b/yoke/build_deps.py
@@ -72,7 +72,8 @@ def remove_container(container):
 class PythonDependencyBuilder(object):
 
     def __init__(self, runtime, project_path, wheelhouse_path, lambda_path,
-                 install_dir, service_name, extra_packages=None):
+                 install_dir, service_name, extra_packages=None,
+                 build_openssl=False, build_libffi=False, build_libxml=False):
         """Initialize dependency builder object.
 
         :param runtime: Lambda Python runtime version.
@@ -96,6 +97,9 @@ class PythonDependencyBuilder(object):
         self.install_dir = install_dir
         self.service_name = service_name
         self.extra_packages = extra_packages or []
+        self.build_openssl = build_openssl
+        self.build_libffi = build_libffi
+        self.build_libxml = build_libxml
 
     def should_rebuild(self):
         # There's a way to force rebuilding of dependencies
@@ -155,6 +159,9 @@ class PythonDependencyBuilder(object):
                 command='/bin/bash -c "./build_wheels.sh"',
                 detach=True,
                 environment={
+                    'BUILD_OPENSSL': '1' if self.build_openssl else '0',
+                    'BUILD_LIBFFI': '1' if self.build_libffi else '0',
+                    'BUILD_LIBXML': '1' if self.build_libxml else '0',
                     'EXTRA_PACKAGES': ' '.join(self.extra_packages),
                     'PY_VERSION': PYTHON_VERSION_MAP[self.runtime],
                 },

--- a/yoke/deploy.py
+++ b/yoke/deploy.py
@@ -125,6 +125,9 @@ class Deployment(object):
                     install_dir=install_dir,
                     service_name=service_name,
                     extra_packages=dependency_config.get('packages'),
+                    build_openssl=dependency_config.get('openssl', False),
+                    build_libffi=dependency_config.get('libffi', False),
+                    build_libxml=dependency_config.get('libxml', False),
                 )
                 builder.build()
 


### PR DESCRIPTION
This allows us for example to build cryptography wheels against the newest version of OpenSSL instead of 0.9.8, which isn't supported anymore, but it's the only version available on CentOS5 used as the base image for building dependencies according to PEP-513.