### PR TITLE
Ensure latest setuptools is installed

### DIFF
--- a/yoke/templates.py
+++ b/yoke/templates.py
@@ -212,6 +212,9 @@ fi
 
 PYBIN="/opt/python/${PY_VERSION}/bin"
 
+# Make sure we're using the latest version of setuptools
+${PYBIN}/pip install -U setuptools
+
 ${PYBIN}/pip wheel --no-binary :all: -w /wheelhouse -r /src/requirements.txt
 
 # Make sure we're using the latest version of auditwheel


### PR DESCRIPTION
Some packages dependencies might require a recent version of setuptools (>=30), but the manylinux Docker image ships with 28.8.0 out of the box.