### PR TITLE
Support individually encrypted secretConfig items

### DIFF
--- a/yoke/utils.py
+++ b/yoke/utils.py
@@ -8,6 +8,8 @@ from six import string_types
 
 LOG = logging.getLogger(__name__)
 
+ENCRYPTED_PREFIX = 'encrypted::'
+
 
 def check_encryption_required_fields(stage):
     for field in ['keyRegion', 'keyName']:
@@ -16,39 +18,70 @@ def check_encryption_required_fields(stage):
                             "used.".format(field))
 
 
+def is_value_already_encrypted(value):
+    return value.startswith(ENCRYPTED_PREFIX)
+
+
 def decrypt(config, output=False):
     stage = config['stage']
     check_encryption_required_fields(config['stages'][stage])
-
-    enc_config = get_secret_config(config, stage)
-    if not isinstance(enc_config, string_types):
-        raise Exception('Secret config for stage {} is not a '
-                        'string! Did you forget to encrypt '
-                        'first?'.format(stage))
-    stage_cfg = base64.b64decode(enc_config)
     region = config['stages'][stage]['keyRegion']
     kms = boto3.client('kms', region_name=region)
-    resp = kms.decrypt(CiphertextBlob=stage_cfg)
-    plain = json.loads(resp['Plaintext'])
-    if output:
-        print('Decrypted config for stage {}:\n\n{}'.format(
-            stage,
-            yaml.round_trip_dump(plain)))
-    return plain
+
+    enc_config = get_secret_config(config, stage)
+    if isinstance(enc_config, string_types):
+        # This is the old-style secretConfig, when everything was encrypted
+        # into a single string.
+        stage_cfg = base64.b64decode(enc_config)
+        resp = kms.decrypt(CiphertextBlob=stage_cfg)
+        plain = json.loads(resp['Plaintext'])
+        if output:
+            print('Decrypted config for stage {}:\n\n{}'.format(
+                stage,
+                yaml.round_trip_dump(plain)))
+        return plain
+    elif isinstance(enc_config, dict):
+        # This is the new way, where all config items are encrypted separately.
+        plain = {}
+        for key, value in enc_config.items():
+            if is_value_already_encrypted(value):
+                ciphertext_blob = base64.b64decode(
+                    value[len(ENCRYPTED_PREFIX):])
+                resp = kms.decrypt(CiphertextBlob=ciphertext_blob)
+                plain[key] = resp['Plaintext']
+            else:
+                raise Exception('Found unencrypted item in secretConfig: '
+                                '{}'.format(key))
+        if output:
+            print('Decrypted config for stage {}:\n\n{}'.format(
+                stage,
+                yaml.round_trip_dump(plain)))
+        return plain
 
 
 def encrypt(config, output=False):
     stage = config['stages'][config['stage']]
     check_encryption_required_fields(stage)
     secret_config = get_secret_config(config, config['stage'])
-    kms = boto3.client('kms', region_name=stage['keyRegion'])
-    key_name = 'alias/{}'.format(stage['keyName'])
-    resp = kms.encrypt(KeyId=key_name,
-                       Plaintext=json.dumps(secret_config).encode('utf-8'))
+    if isinstance(secret_config, string_types):
+        raise Exception('Secret config for stage {} is already '
+                        'encrypted.'.format(config['stage']))
     if output:
-        print('Encrypted config for stage {}:\nsecretConfig: "{}"\n'.format(
-            config['stage'],
-            base64.b64encode(resp['CiphertextBlob']).decode('utf-8')))
+        print('Encrypted config for stage {}:\nsecretConfig:'.format(
+            config['stage']))
+    for key, value in secret_config.items():
+        if is_value_already_encrypted(value):
+            if output:
+                print('  {}: "{}"'.format(key, value))
+            continue
+        kms = boto3.client('kms', region_name=stage['keyRegion'])
+        key_name = 'alias/{}'.format(stage['keyName'])
+        resp = kms.encrypt(KeyId=key_name,
+                           Plaintext=value.encode('utf-8'))
+        if output:
+            encrypted_blob = base64.b64encode(
+                resp['CiphertextBlob']).decode('utf-8')
+            print('  {}: "{}{}"'.format(key, ENCRYPTED_PREFIX, encrypted_blob))
 
 
 def format_env(env_list):


### PR DESCRIPTION
This is a pretty simple approach (couldn't use `b64decode` to detect encryption, because PEM keys are base64-encoded, so they aren't detected properly), tested to be backwards-compatible.

The problem it solves is that KMS has a limit of 4096 bytes that it would encrypt, and sometimes we have more secrets than that.

If the approach is accepted, I'll adjust docs accordingly.